### PR TITLE
Length Issues & Workspace fixes

### DIFF
--- a/export/document-export/src/main/resources/templates/profile/datatype/component.xsl
+++ b/export/document-export/src/main/resources/templates/profile/datatype/component.xsl
@@ -25,7 +25,7 @@
                 <xsl:if test="$showConfLength='true'">
                     <xsl:element name="td">
                         <xsl:choose>
-                            <xsl:when test="@complex = 'true' or @confLength='NA' or @usage = 'X'">
+                            <xsl:when test="@complex = 'true' or @lengthType != 'ConfLength' or @confLength='NA' or @usage = 'X'">
                                 <xsl:attribute name="class"><xsl:text>greyCell</xsl:text></xsl:attribute>
                             </xsl:when>
                             <xsl:otherwise>
@@ -204,7 +204,7 @@
             <xsl:if test="$columnDisplay.dataType.length = 'true'">
                 <xsl:element name="td">
                     <xsl:choose>
-                        <xsl:when test="@complex='true' or @usage = 'X' or @minLength = 'NA' or @maxLength = 'NA'">
+                        <xsl:when test="@complex='true' or @usage = 'X' or @lengthType != 'Length' or @minLength = 'NA' or @maxLength = 'NA'">
                             <xsl:attribute name="class"><xsl:text>greyCell</xsl:text></xsl:attribute>
                         </xsl:when>
                         <xsl:otherwise>

--- a/export/document-export/src/main/resources/templates/profile/segment/segmentField.xsl
+++ b/export/document-export/src/main/resources/templates/profile/segment/segmentField.xsl
@@ -202,7 +202,7 @@
             <xsl:if test="$columnDisplay.segment.length = 'true'">
                 <xsl:element name="td">
                     <xsl:choose>
-                        <xsl:when test="@complex='true' or @usage = 'X' or @minLength = 'NA' or @maxLength = 'NA'">
+                        <xsl:when test="@complex='true' or @usage = 'X' or @lengthType != 'Length'  or @minLength = 'NA' or @maxLength = 'NA'">
                             <xsl:attribute name="class"><xsl:text>greyCell</xsl:text></xsl:attribute>
                         </xsl:when>
                         <xsl:otherwise>
@@ -272,7 +272,7 @@
                 <xsl:if test="$showConfLength='true'">
                     <xsl:element name="td">
                         <xsl:choose>
-                            <xsl:when test="@complex = 'true' or @confLength='NA' or @usage = 'X'">
+                            <xsl:when test="@complex = 'true' or @lengthType != 'ConfLength' or @confLength='NA' or @usage = 'X'">
                                 <xsl:attribute name="class"><xsl:text>greyCell</xsl:text></xsl:attribute>
                             </xsl:when>
                             <xsl:otherwise>

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/XMLSerializeServiceImpl.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/XMLSerializeServiceImpl.java
@@ -290,26 +290,6 @@ public class XMLSerializeServiceImpl implements XMLSerializeService {
 									elmComponent.addAttribute(new Attribute("ConfLength", "NA"));
 								}
 
-							} else {
-								if (c.getMinLength() != null && !c.getMinLength().isEmpty()) {
-									elmComponent.addAttribute(new Attribute("MinLength", this.str(c.getMinLength())));
-
-								} else {
-									elmComponent.addAttribute(new Attribute("MinLength", "NA"));
-								}
-
-								if (c.getMaxLength() != null && !c.getMaxLength().isEmpty()) {
-									elmComponent.addAttribute(new Attribute("MaxLength", this.str(c.getMaxLength())));
-
-								} else {
-									elmComponent.addAttribute(new Attribute("MaxLength", "NA"));
-
-								}
-								if (c.getConfLength() != null && !c.getConfLength().equals("")) {
-									elmComponent.addAttribute(new Attribute("ConfLength", this.str(c.getConfLength())));
-								} else {
-									elmComponent.addAttribute(new Attribute("ConfLength", "NA"));
-								}
 							}
 
 							elmDatatype.appendChild(elmComponent);
@@ -1038,29 +1018,6 @@ public class XMLSerializeServiceImpl implements XMLSerializeService {
 							elmComponent.addAttribute(new Attribute("ConfLength", "NA"));
 						}
 
-					} else {
-						if (c.getModel().getMinLength() != null && !c.getModel().getMinLength().isEmpty()) {
-							elmComponent
-									.addAttribute(new Attribute("MinLength", this.str(c.getModel().getMinLength())));
-
-						} else {
-							elmComponent.addAttribute(new Attribute("MinLength", "NA"));
-						}
-
-						if (c.getModel().getMaxLength() != null && !c.getModel().getMaxLength().isEmpty()) {
-							elmComponent
-									.addAttribute(new Attribute("MaxLength", this.str(c.getModel().getMaxLength())));
-
-						} else {
-							elmComponent.addAttribute(new Attribute("MaxLength", "NA"));
-
-						}
-						if (c.getModel().getConfLength() != null && !c.getModel().getConfLength().equals("")) {
-							elmComponent
-									.addAttribute(new Attribute("ConfLength", this.str(c.getModel().getConfLength())));
-						} else {
-							elmComponent.addAttribute(new Attribute("ConfLength", "NA"));
-						}
 					}
 					elmDatatype.appendChild(elmComponent);
 				}
@@ -1292,7 +1249,6 @@ public class XMLSerializeServiceImpl implements XMLSerializeService {
 							if (f.getModel().getMinLength() != null && !f.getModel().getMinLength().isEmpty()) {
 								elmField.addAttribute(
 										new Attribute("MinLength", this.str(f.getModel().getMinLength())));
-
 							} else {
 								elmField.addAttribute(new Attribute("MinLength", "NA"));
 							}
@@ -1300,7 +1256,6 @@ public class XMLSerializeServiceImpl implements XMLSerializeService {
 							if (f.getModel().getMaxLength() != null && !f.getModel().getMaxLength().isEmpty()) {
 								elmField.addAttribute(
 										new Attribute("MaxLength", this.str(f.getModel().getMaxLength())));
-
 							} else {
 								elmField.addAttribute(new Attribute("MaxLength", "NA"));
 
@@ -1310,30 +1265,6 @@ public class XMLSerializeServiceImpl implements XMLSerializeService {
 							elmField.addAttribute(new Attribute("MinLength", "NA"));
 							elmField.addAttribute(new Attribute("MaxLength", "NA"));
 
-							if (f.getModel().getConfLength() != null && !f.getModel().getConfLength().equals("")) {
-								elmField.addAttribute(
-										new Attribute("ConfLength", this.str(f.getModel().getConfLength())));
-							} else {
-								elmField.addAttribute(new Attribute("ConfLength", "NA"));
-							}
-
-						} else {
-							if (f.getModel().getMinLength() != null && !f.getModel().getMinLength().isEmpty()) {
-								elmField.addAttribute(
-										new Attribute("MinLength", this.str(f.getModel().getMinLength())));
-
-							} else {
-								elmField.addAttribute(new Attribute("MinLength", "NA"));
-							}
-
-							if (f.getModel().getMaxLength() != null && !f.getModel().getMaxLength().isEmpty()) {
-								elmField.addAttribute(
-										new Attribute("MaxLength", this.str(f.getModel().getMaxLength())));
-
-							} else {
-								elmField.addAttribute(new Attribute("MaxLength", "NA"));
-
-							}
 							if (f.getModel().getConfLength() != null && !f.getModel().getConfLength().equals("")) {
 								elmField.addAttribute(
 										new Attribute("ConfLength", this.str(f.getModel().getConfLength())));

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
@@ -856,7 +856,7 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .handleByUser()
                 .target(id, type)
                 .locationInfo(locationInfo.getPathId(), locationInfo, PropertyType.LENGTH)
-                .message("Primitive datatype should have one of Length and ConfLength")
+                .message("Primitive datatype does not have one of Length or ConfLength")
                 .entry();
 	}
 
@@ -867,7 +867,7 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .handleByUser()
                 .target(id, type)
                 .locationInfo(locationInfo.getPathId(), locationInfo, PropertyType.LENGTH)
-                .message(String.format("Max Length should be a number, '*' or 'NA'. The current Max Length is %s", maxLength))
+                .message(String.format("Max Length should be a number or '*'. The current Max Length is '%s'", maxLength))
                 .entry();
 	}
 
@@ -878,7 +878,7 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .handleByUser()
                 .target(id, type)
                 .locationInfo(locationInfo.getPathId(), locationInfo, PropertyType.LENGTH)
-                .message(String.format("Min Length should be a number or 'NA'. The current Min Length is %s", minLength))
+                .message(String.format("Min Length should be a number. The current Min Length is '%s'", minLength))
                 .entry();
 	}
 
@@ -889,7 +889,7 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .handleByUser()
                 .target(id, type)
                 .locationInfo(locationInfo.getPathId(), locationInfo, PropertyType.LENGTH)
-                .message(String.format("Min Length value is greater than Max Length. The current Min Length is %s and current Max Length is %s", minLength, maxLength))
+                .message(String.format("Min Length value is greater than Max Length. The current Min Length is '%s' and current Max Length is '%s'", minLength, maxLength))
                 .entry();
 	}
 

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/dtm-stucture/dtm-structure.component.ts
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/dtm-stucture/dtm-structure.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import {SelectItem} from 'primeng/api';
+import { SelectItem } from 'primeng/api';
 import { BehaviorSubject, Observable, of, Subscription } from 'rxjs';
 import { IResource } from '../../models/resource.interface';
 import { ChangeType, IChange, PropertyType } from '../../models/save-change';
@@ -33,38 +33,38 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
       if (resource.name === 'DTM') {
         this.dateTimeConstraints = {
           dateTimeComponentDefinitions: [
-            {position: 1, name: 'Year', format: 'YYYY', usage: 'R'},
-            {position: 2, name: 'Month', format: 'MM', usage: 'O'},
-            {position: 3, name: 'Day', format: 'DD', usage: 'O'},
-            {position: 4, name: 'Hour', format: 'HH', usage: 'O'},
-            {position: 5, name: 'Minute', format: 'MM', usage: 'O'},
-            {position: 6, name: 'Second', format: 'SS', usage: 'O'},
-            {position: 7, name: '1/10 second', format: 'S...', usage: 'O'},
-            {position: 8, name: '1/100 second', format: '.S..', usage: 'O'},
-            {position: 9, name: '1/1000 second', format: '..S.', usage: 'O'},
-            {position: 10, name: '1/10000 second', format: '...S', usage: 'O'},
-            {position: 11, name: 'Time Zone', format: '+/-ZZZZ', usage: 'O'},
+            { position: 1, name: 'Year', format: 'YYYY', usage: 'R' },
+            { position: 2, name: 'Month', format: 'MM', usage: 'O' },
+            { position: 3, name: 'Day', format: 'DD', usage: 'O' },
+            { position: 4, name: 'Hour', format: 'HH', usage: 'O' },
+            { position: 5, name: 'Minute', format: 'MM', usage: 'O' },
+            { position: 6, name: 'Second', format: 'SS', usage: 'O' },
+            { position: 7, name: '1/10 second', format: 'S...', usage: 'O' },
+            { position: 8, name: '1/100 second', format: '.S..', usage: 'O' },
+            { position: 9, name: '1/1000 second', format: '..S.', usage: 'O' },
+            { position: 10, name: '1/10000 second', format: '...S', usage: 'O' },
+            { position: 11, name: 'Time Zone', format: '+/-ZZZZ', usage: 'O' },
           ],
         };
       } else if (resource.name === 'DT') {
         this.dateTimeConstraints = {
           dateTimeComponentDefinitions: [
-            {position: 1, name: 'Year', format: 'YYYY', usage: 'R'},
-            {position: 2, name: 'Month', format: 'MM', usage: 'O'},
-            {position: 3, name: 'Day', format: 'DD', usage: 'O'},
+            { position: 1, name: 'Year', format: 'YYYY', usage: 'R' },
+            { position: 2, name: 'Month', format: 'MM', usage: 'O' },
+            { position: 3, name: 'Day', format: 'DD', usage: 'O' },
           ],
         };
-      }  else if (resource.name === 'TM') {
+      } else if (resource.name === 'TM') {
         this.dateTimeConstraints = {
           dateTimeComponentDefinitions: [
-            {position: 4, name: 'Hour', format: 'HH', usage: 'R'},
-            {position: 5, name: 'Minute', format: 'MM', usage: 'O'},
-            {position: 6, name: 'Second', format: 'SS', usage: 'O'},
-            {position: 7, name: '1/10 second', format: 'S...', usage: 'O'},
-            {position: 8, name: '1/100 second', format: '.S..', usage: 'O'},
-            {position: 9, name: '1/1000 second', format: '..S.', usage: 'O'},
-            {position: 10, name: '1/10000 second', format: '...S', usage: 'O'},
-            {position: 11, name: 'Time Zone', format: '+/-ZZZZ', usage: 'O'},
+            { position: 4, name: 'Hour', format: 'HH', usage: 'R' },
+            { position: 5, name: 'Minute', format: 'MM', usage: 'O' },
+            { position: 6, name: 'Second', format: 'SS', usage: 'O' },
+            { position: 7, name: '1/10 second', format: 'S...', usage: 'O' },
+            { position: 8, name: '1/100 second', format: '.S..', usage: 'O' },
+            { position: 9, name: '1/1000 second', format: '..S.', usage: 'O' },
+            { position: 10, name: '1/10000 second', format: '...S', usage: 'O' },
+            { position: 11, name: 'Time Zone', format: '+/-ZZZZ', usage: 'O' },
           ],
         };
       }
@@ -82,11 +82,11 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
     this.changes$ = this.changes.asObservable();
 
     this.usageOptions = [
-      {label: 'R', value: 'R'},
-      {label: 'RE', value: 'RE'},
-      {label: 'O', value: 'O'},
-      {label: 'X', value: 'X'},
-      {label: 'IX', value: 'IX'}
+      { label: 'R', value: 'R' },
+      { label: 'RE', value: 'RE' },
+      { label: 'O', value: 'O' },
+      { label: 'X', value: 'X' },
+      { label: 'IX', value: 'IX' },
     ];
   }
 
@@ -98,23 +98,23 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
 
   loadRegexDataAndUpdateAssertion() {
     if (!this.regexList) {
-      this.http.get('assets/' + this.dtName + ' regex list.csv', {responseType: 'text'})
-          .subscribe((data) => {
-            this.regexList = {};
-            for (const line of data.split(/[\r\n]+/)) {
+      this.http.get('assets/' + this.dtName + ' regex list.csv', { responseType: 'text' })
+        .subscribe((data) => {
+          this.regexList = {};
+          for (const line of data.split(/[\r\n]+/)) {
 
-              const lineSplits = line.split(',');
-              const key = lineSplits[0] + '-' + lineSplits[1] + '-' + lineSplits[2];
+            const lineSplits = line.split(',');
+            const key = lineSplits[0] + '-' + lineSplits[1] + '-' + lineSplits[2];
 
-              this.regexList[key] = {
-                format : lineSplits[3],
-                errorMessage : lineSplits[4],
-                regex : lineSplits[5],
-              };
-            }
+            this.regexList[key] = {
+              format: lineSplits[3],
+              errorMessage: lineSplits[4],
+              regex: lineSplits[5],
+            };
+          }
 
-            this.updateAssertion();
-          });
+          this.updateAssertion();
+        });
     } else {
       this.updateAssertion();
     }
@@ -148,32 +148,29 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
     });
   }
 
-  makeO(position: number) {
+  makeUsageAtPosition(position: number, usage: string) {
     this.dateTimeConstraints.dateTimeComponentDefinitions.forEach((item) => {
       if (item.position < position && item.position !== 11 && item.usage !== 'R' && item.usage !== 'RE') {
-          item.usage = 'O';
+        item.usage = usage;
       }
       if (item.position > position && item.position !== 11 && (item.usage === 'R' || item.usage === 'RE')) {
-          item.usage = 'O';
+        item.usage = usage;
       }
     });
   }
 
+  makeO(position: number) {
+    this.makeUsageAtPosition(position, 'O');
+  }
+
   makeIX(position: number) {
-    this.dateTimeConstraints.dateTimeComponentDefinitions.forEach((item) => {
-      if (item.position < position && item.position !== 11 && item.usage !== 'R' && item.usage !== 'RE') {
-          item.usage = 'IX';
-      }
-      if (item.position > position && item.position !== 11 && (item.usage === 'R' || item.usage === 'RE')) {
-          item.usage = 'IX';
-      }
-    });
+    this.makeUsageAtPosition(position, 'IX');
   }
 
   genHTML(pattern: string) {
     if (pattern && this.dateTimeConstraints.dateTimeComponentDefinitions) {
 
-      let result: string  = pattern.replace('YYYY', '<b>YYYY</b>');
+      let result: string = pattern.replace('YYYY', '<b>YYYY</b>');
 
       for (const item of this.dateTimeConstraints.dateTimeComponentDefinitions) {
         result = this.replaceItemByUsage(item, result);
@@ -235,7 +232,7 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
     });
 
     if (!timeZoneUsage) { timeZoneUsage = 'X'; }
-    if (timeZoneUsage === 'RE' || timeZoneUsage === 'O' || timeZoneUsage === 'IX' ) { timeZoneUsage = 'REO'; }
+    if (timeZoneUsage === 'RE' || timeZoneUsage === 'O' || timeZoneUsage === 'IX') { timeZoneUsage = 'REO'; }
 
     return countR + '-' + countX + '-' + timeZoneUsage;
   }
@@ -279,7 +276,7 @@ export class DtmStructureComponent implements OnInit, OnDestroy {
 
   updateChanges() {
     this.changes.emit({
-      location: this.dtName ,
+      location: this.dtName,
       propertyType: PropertyType.DTMSTRUC,
       propertyValue: this.dateTimeConstraints,
       oldPropertyValue: null,

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.html
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.html
@@ -10,14 +10,14 @@
       <ng-container *ngSwitchCase="true">
         <input style="width: 100%;" class="range-input" type="text" [name]="location + 'conf-length'" [id]="location + 'conf-length'" placeholder="Conf Length" [ngModelOptions]="{updateOn: 'blur'}" [(ngModel)]="val.value" (ngModelChange)="confLengthChange($event)">
         <button class="btn btn-sm btn-danger" (click)="clear()" style="margin-left: 5px;">
-          <i class="fa fa-times"></i>
+          <i class="fa fa-trash"></i>
         </button>
       </ng-container>
       <div *ngSwitchCase="false">
         <ng-container *ngTemplateOutlet="display; context : { $implicit : val, active: false }"></ng-container>
       </div>
-      <button *ngIf="val && lengthType && lengthType === lengthTypes.UNSET && leaf" class="btn btn-sm btn-primary" (click)="set()">
-        <i class="fa fa-pencil"></i>
+      <button *ngIf="val && lengthType && lengthType === lengthTypes.UNSET && leaf" class="btn btn-sm btn-info" (click)="set()">
+        <i class="fa fa-check"></i>
       </button>
     </ng-container>
     <ng-container *ngSwitchCase="true">
@@ -26,7 +26,7 @@
   </ng-container>
 
   <ng-template #display let-val let-active="active">
-    <strong [ngClass]="{ 'treetable-light': !active }" >{{val.value ? val.value : 'NA'}}</strong>
+    <strong [ngClass]="{ 'treetable-light': !active, 'strikethrough': !active && val.value && val.value !== 'NA'  }" >{{val.value || 'NA'}}</strong>
   </ng-template>
 
 </div>

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.scss
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.scss
@@ -2,3 +2,10 @@
   display: flex;
   flex-direction: row;
 }
+
+.strikethrough {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  text-decoration-color: #b38d8d;
+
+}

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.ts
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/conformance-length/conformance-length.component.ts
@@ -47,6 +47,10 @@ export class ConformanceLengthComponent extends HL7v2TreeColumnComponent<IString
   set() {
     this.onChange<string>(this.lengthType, LengthType.ConfLength, PropertyType.LENGTHTYPE, ChangeType.UPDATE);
     this.updateLengthType.emit(LengthType.ConfLength);
+    if (!this.val.value || this.val.value === 'NA') {
+      this.val.value = '';
+      this.confLengthChange('');
+    }
   }
 
   isActualChange<X>(change: IChange<X>): boolean {

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.html
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.html
@@ -14,14 +14,14 @@
           <input [ngModelOptions]="{updateOn: 'blur'}" class="range-input" type="text" [name]="location + 'max-length'" [id]="location + 'max-length'" placeholder="Max" [(ngModel)]="val.max" (ngModelChange)="maxChange($event)">
         </div>
         <button class="btn btn-sm btn-danger" (click)="clear()">
-          <i class="fa fa-times"></i>
+          <i class="fa fa-trash"></i>
         </button>
       </ng-container>
       <div *ngSwitchCase="false">
         <ng-container *ngTemplateOutlet="display; context : { $implicit : val, active: false }"></ng-container>
       </div>
-      <button *ngIf="lengthType && lengthType === lengthTypes.UNSET && leaf" class="btn btn-sm btn-primary" (click)="set()">
-        <i class="fa fa-pencil"></i>
+      <button *ngIf="lengthType && lengthType === lengthTypes.UNSET && leaf" class="btn btn-sm btn-info" (click)="set()">
+        <i class="fa fa-check"></i>
       </button>
     </ng-container>
     <ng-container *ngSwitchCase="true">
@@ -31,5 +31,5 @@
 </div>
 
 <ng-template #display let-val let-active="active">
-  <strong [ngClass]="{ 'treetable-light': !active }" >[{{val.min}} .. {{val.max}}]</strong>
+  <strong [ngClass]="{ 'treetable-light': !active, 'strikethrough': !active }" >[{{val.min || 'NA'}} .. {{val.max || 'NA'}}]</strong>
 </ng-template>

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.scss
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.scss
@@ -2,3 +2,10 @@
   display: flex;
   flex-direction: row;
 }
+
+.strikethrough {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  text-decoration-color: #b38d8d;
+
+}

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.ts
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/length/length.component.ts
@@ -50,6 +50,14 @@ export class LengthComponent extends HL7v2TreeColumnComponent<ILengthRange> impl
   set() {
     this.onChange<string>(this.lengthType, LengthType.Length, PropertyType.LENGTHTYPE, ChangeType.UPDATE);
     this.updateLengthType.emit(LengthType.Length);
+    if (!this.val.min || this.val.min === 'NA') {
+      this.val.min = '';
+      this.minChange('');
+    }
+    if (!this.val.max || this.val.max === 'NA') {
+      this.val.max = '';
+      this.maxChange('');
+    }
   }
 
   isActualChange<X>(change: IChange<X>): boolean {

--- a/serialization/src/main/java/gov/nist/hit/hl7/igamt/serialization/newImplementation/service/DatatypeSerializationServiceImpl.java
+++ b/serialization/src/main/java/gov/nist/hit/hl7/igamt/serialization/newImplementation/service/DatatypeSerializationServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import gov.nist.diff.domain.DeltaAction;
+import gov.nist.hit.hl7.igamt.common.base.domain.*;
 import gov.nist.hit.hl7.igamt.common.change.entity.domain.PropertyType;
 import gov.nist.hit.hl7.igamt.compositeprofile.domain.GeneratedResourceMetadata;
 import gov.nist.hit.hl7.igamt.delta.domain.ConformanceStatementDelta;
@@ -20,13 +21,6 @@ import gov.nist.hit.hl7.igamt.service.impl.ResourceSkeletonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import gov.nist.hit.hl7.igamt.common.base.domain.ActiveStatus;
-import gov.nist.hit.hl7.igamt.common.base.domain.Comment;
-import gov.nist.hit.hl7.igamt.common.base.domain.DocumentStructureDataModel;
-import gov.nist.hit.hl7.igamt.common.base.domain.GenerationDirective;
-import gov.nist.hit.hl7.igamt.common.base.domain.Resource;
-import gov.nist.hit.hl7.igamt.common.base.domain.Type;
-import gov.nist.hit.hl7.igamt.common.base.domain.Usage;
 import gov.nist.hit.hl7.igamt.common.binding.domain.Binding;
 import gov.nist.hit.hl7.igamt.datatype.domain.ComplexDatatype;
 import gov.nist.hit.hl7.igamt.datatype.domain.Component;
@@ -222,6 +216,7 @@ public class DatatypeSerializationServiceImpl implements DatatypeSerializationSe
           .addAttribute(new Attribute("id", component.getId() != null ? component.getId() : ""));
           componentElement.addAttribute(
               new Attribute("name", component.getName() != null ? component.getName() : ""));
+          componentElement.addAttribute(new Attribute("lengthType", component.getLengthType().getValue()));
           componentElement.addAttribute(new Attribute("maxLength",
               component.getMaxLength() != null ? component.getMaxLength() : ""));
           componentElement.addAttribute(new Attribute("minLength",

--- a/serialization/src/main/java/gov/nist/hit/hl7/igamt/serialization/newImplementation/service/SegmentSerializationServiceImpl.java
+++ b/serialization/src/main/java/gov/nist/hit/hl7/igamt/serialization/newImplementation/service/SegmentSerializationServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import gov.nist.hit.hl7.igamt.common.base.domain.*;
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
 import gov.nist.hit.hl7.igamt.common.base.exception.ResourceNotFoundException;
 import gov.nist.hit.hl7.igamt.common.change.entity.domain.PropertyType;
@@ -24,10 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import gov.nist.diff.domain.DeltaAction;
-import gov.nist.hit.hl7.igamt.common.base.domain.Comment;
-import gov.nist.hit.hl7.igamt.common.base.domain.GenerationDirective;
-import gov.nist.hit.hl7.igamt.common.base.domain.Type;
-import gov.nist.hit.hl7.igamt.common.base.domain.Usage;
 import gov.nist.hit.hl7.igamt.common.binding.domain.Binding;
 import gov.nist.hit.hl7.igamt.datatype.domain.Datatype;
 import gov.nist.hit.hl7.igamt.datatype.exception.DatatypeNotFoundException;
@@ -268,6 +265,7 @@ public class SegmentSerializationServiceImpl implements SegmentSerializationServ
                 new Attribute("constantValue", field.getConstantValue() != null ? field.getConstantValue() : ""));
             fieldElement
             .addAttribute(new Attribute("id", field.getId() != null ? field.getId() : ""));
+            fieldElement.addAttribute(new Attribute("lengthType", field.getLengthType().getValue()));
             fieldElement.addAttribute(new Attribute("maxLength",
                 field.getMaxLength() != null ? field.getMaxLength() : ""));
             fieldElement.addAttribute(new Attribute("minLength",

--- a/web-app/src/main/java/gov/nist/hit/hl7/igamt/access/security/AccessControlService.java
+++ b/web-app/src/main/java/gov/nist/hit/hl7/igamt/access/security/AccessControlService.java
@@ -52,7 +52,11 @@ public class AccessControlService {
                 return this.evaluateAccessLevel(L(AccessLevel.READ), requested);
             }
         } else {
-            return false;
+            if(isAdmin(user)) {
+                return this.evaluateAccessLevel(L(AccessLevel.READ), requested);
+            } else {
+                return false;
+            }
         }
     }
 
@@ -207,7 +211,10 @@ public class AccessControlService {
                 case VIEW:
                     return L(AccessLevel.READ);
             }
-        }        
+        }
+        if(isAdmin(user)) {
+            return L(AccessLevel.READ);
+        }
         return null;
     }
 

--- a/web-app/src/main/java/gov/nist/hit/hl7/igamt/web/app/workspace/WorkspaceController.java
+++ b/web-app/src/main/java/gov/nist/hit/hl7/igamt/web/app/workspace/WorkspaceController.java
@@ -340,7 +340,7 @@ public class WorkspaceController {
 
 	@RequestMapping(value = "/api/workspace/{wsId}/folder/{folderId}/document/{documentType}/{documentId}", method = RequestMethod.DELETE, produces = { "application/json" })
 	@ResponseBody
-	@PreAuthorize("AccessWorkspaceFolder(workspaceId, folderId, WRITE) && AccessResource(#documentType, #documentId, WRITE)")
+	@PreAuthorize("AccessWorkspaceFolder(#workspaceId, #folderId, WRITE) && AccessResource(#documentType, #documentId, WRITE)")
 	public WorkspaceInfo deleteDocument(
 			@PathVariable("wsId") String workspaceId,
 			@PathVariable("folderId") String folderId,


### PR DESCRIPTION
Fix Length Issues
- Make it clear the greyed out values are not applicable by strikethrough text
- Verification only validates the selected length type
- Export only export the selected length type
Workspace
- Fix IG delete failure (inside workspace)
- Allow admin to have view access to workspace igs

Decisions for length handling:
```
When LENGTH = UNSET
    ui:
	min/max value is greyed out and strikethrough 
            if value is empty display NA, if value is NA display NA
	conf length is greyed out and strikethrough 
            if value is empty display NA, if value is NA display NA
    export:
	min/max is NOT exported
	conf length is NOT exported
	
When LENGTH = MIN MAX
    ui on activate:
        if min/max value is NA, set value to empty and display input field
        if min/max has actual value, display input field with value
    ui:
	min/max is editable
	conf length is greyed out and strikethrough 
            if value is empty display NA, if value is NA display NA	
    export:
	min/max is exported
	conf length is NOT exported

When LENGTH = CONF LENGTH
    ui on activate:
        if conf length value is NA, set value to empty and display input field
        if conf length has actual value, display input field with value
    ui:
	min/max is greyed out and strikethrough 
            if value is empty display NA, if value is NA display NA
	conf length is editable
    export:
	min/max is NOT exported
	conf length is exported
```