### PR TITLE
Add verification detections for dynamic mapping and Co-Constraint

### DIFF
--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/model/ResourceSkeleton.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/model/ResourceSkeleton.java
@@ -3,6 +3,7 @@ package gov.nist.hit.hl7.igamt.ig.model;
 import com.google.common.base.Strings;
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
 import gov.nist.hit.hl7.igamt.common.base.exception.ResourceNotFoundException;
+import gov.nist.hit.hl7.igamt.common.binding.domain.ResourceBinding;
 import gov.nist.hit.hl7.igamt.constraints.domain.assertion.InstancePath;
 import gov.nist.hit.hl7.igamt.service.impl.ResourceSkeletonService;
 
@@ -12,6 +13,7 @@ import java.util.List;
 public class ResourceSkeleton {
     protected final ResourceRef resourceRef;
     protected DisplayElement resource;
+	protected ResourceBinding resourceBindings;
     protected final ResourceSkeletonService resourceSkeletonService;
     protected List<ResourceSkeletonBone> children;
 
@@ -31,6 +33,7 @@ public class ResourceSkeleton {
             ResourceSkeletonInfo resourceSkeletonInfo = this.resourceSkeletonService.loadSkeleton(resourceRef, this);
             this.setChildren(resourceSkeletonInfo.getChildren());
             this.setResource(resourceSkeletonInfo.getResource());
+			this.setResourceBindings(resourceSkeletonInfo.getBinding());
             return resourceSkeletonInfo;
         }
         return null;
@@ -131,4 +134,12 @@ public class ResourceSkeleton {
         return this;
     }
 
+	public ResourceBinding getResourceBindings() throws ResourceNotFoundException {
+		this.lazyLoad();
+		return resourceBindings;
+	}
+
+	protected void setResourceBindings(ResourceBinding resourceBindings) {
+		this.resourceBindings = resourceBindings;
+	}
 }

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/model/ResourceSkeletonInfo.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/model/ResourceSkeletonInfo.java
@@ -1,16 +1,19 @@
 package gov.nist.hit.hl7.igamt.ig.model;
 
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
+import gov.nist.hit.hl7.igamt.common.binding.domain.ResourceBinding;
 
 import java.util.List;
 
 public class ResourceSkeletonInfo {
     List<ResourceSkeletonBone> children;
     DisplayElement resource;
+    ResourceBinding binding;
 
-    public ResourceSkeletonInfo(List<ResourceSkeletonBone> children, DisplayElement resource) {
+    public ResourceSkeletonInfo(List<ResourceSkeletonBone> children, DisplayElement resource, ResourceBinding binding) {
         this.children = children;
         this.resource = resource;
+        this.binding = binding;
     }
 
 
@@ -28,5 +31,13 @@ public class ResourceSkeletonInfo {
 
     public void setChildren(List<ResourceSkeletonBone> children) {
         this.children = children;
+    }
+
+    public ResourceBinding getBinding() {
+        return binding;
+    }
+
+    public void setBinding(ResourceBinding binding) {
+        this.binding = binding;
     }
 }

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/ResourceSkeletonService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/ResourceSkeletonService.java
@@ -69,9 +69,9 @@ public class ResourceSkeletonService {
                     parent,
                     this
             )).collect(Collectors.toList());
-            return new ResourceSkeletonInfo(children, resource);
+            return new ResourceSkeletonInfo(children, resource, datatype.getBinding());
         } else {
-            return new ResourceSkeletonInfo(Collections.emptyList(), resource);
+            return new ResourceSkeletonInfo(Collections.emptyList(), resource, datatype.getBinding());
         }
     }
     public ResourceSkeletonInfo loadSegmentSkeleton(String id, LocationInfo parentLocationInfo, ResourceSkeleton parent) throws ResourceNotFoundException {
@@ -93,7 +93,7 @@ public class ResourceSkeletonService {
                 parent,
                 this
         )).collect(Collectors.toList());
-        return new ResourceSkeletonInfo(children, resource);
+        return new ResourceSkeletonInfo(children, resource, segment.getBinding());
     }
 
     public ResourceSkeletonInfo loadConformanceProfileSkeleton(String id, ResourceSkeleton parent) throws ResourceNotFoundException {
@@ -103,7 +103,7 @@ public class ResourceSkeletonService {
         }
 
         DisplayElement resource = this.conformanceProfileService.convertConformanceProfile(conformanceProfile, 0);
-        return new ResourceSkeletonInfo(getGroupChildren(resource, conformanceProfile.getChildren(), null, parent), resource);
+        return new ResourceSkeletonInfo(getGroupChildren(resource, conformanceProfile.getChildren(), null, parent), resource, conformanceProfile.getBinding());
     }
 
     public List<ResourceSkeletonBone> getGroupChildren(DisplayElement parent, Set<SegmentRefOrGroup> segmentRefOrGroups, LocationInfo parentLocationInfo, ResourceSkeleton parentSkeleton) {
@@ -162,6 +162,9 @@ public class ResourceSkeletonService {
             locationInfo.setPositionalPath(append(parent.getPositionalPath(), ".", position + ""));
             if(location.equals(Type.GROUP) || location.equals(Type.SEGMENTREF)) {
                 locationInfo.setHl7Path(append(parent.getHl7Path(), ".", name));
+            }
+            else if(location.equals(Type.FIELD)) {
+                locationInfo.setHl7Path(append(parent.getHl7Path(), "-", position + ""));
             }
             else {
                 locationInfo.setHl7Path(append(parent.getHl7Path(), ".", position + ""));

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/SimpleCoConstraintXMLSerialization.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/SimpleCoConstraintXMLSerialization.java
@@ -228,12 +228,12 @@ public class SimpleCoConstraintXMLSerialization implements CoConstraintXMLSerial
 
         if(!Strings.isNullOrEmpty(context.getPathId())) {
             InstancePath groupInstancePath = this.generatePathService.getInstancePath(context.getPathId(), "*");
-            String script = this.assertionXMLSerialization.generateAssertionScript(assertion, Level.GROUP, cpId, groupInstancePath, false);
+            String script = this.assertionXMLSerialization.generateAssertionScript(assertion, Level.GROUP, cpId, groupInstancePath, true);
             Element element = new Element("Assertion");
             element.appendChild(this.innerXMLHandler(script));
             condition.appendChild(element);
         } else {
-            String script = this.assertionXMLSerialization.generateAssertionScript(assertion, Level.CONFORMANCEPROFILE, cpId, null, false);
+            String script = this.assertionXMLSerialization.generateAssertionScript(assertion, Level.CONFORMANCEPROFILE, cpId, null, true);
             condition.appendChild(script);
         }
 

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/SimpleResourceBindingService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/SimpleResourceBindingService.java
@@ -28,7 +28,7 @@ public class SimpleResourceBindingService implements ResourceBindingService {
     public FlatResourceBinding getFlatResourceBindings(ResourceBinding resourceBinding) {
         FlatResourceBinding structResourceBindings = resourceBinding.getChildren() != null && resourceBinding.getChildren().size() > 0 ?
                 resourceBinding.getChildren().stream()
-                        .map((a) -> this.getResourceBindings(null, a))
+                        .map((child) -> this.getResourceBindings(null, child))
                         .reduce(new FlatResourceBinding(), this::merge) : new FlatResourceBinding();
 
         if(resourceBinding.getConformanceStatements() != null) {

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/VerificationEntryService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/VerificationEntryService.java
@@ -30,6 +30,11 @@ public interface VerificationEntryService {
     IgamtObjectError PathShouldBePrimitive(Location location, String id, Type type, LocationInfo path, String pathQualifier);
     IgamtObjectError PathShouldBeComplex(Location location, String id, Type type, LocationInfo path, String pathQualifier);
 
+    // Dynamic Mapping
+    IgamtObjectError DynamicMappingValueNotFound(Location location, String id, Type type, String value, Set<String> valueSets);
+    IgamtObjectError DynamicMappingValueExcludedUsage(Location location, String id, Type type, String value, Set<String> valueSets);
+    IgamtObjectError DynamicMappingMissingValue(Location location, String id, Type type, Set<String> value, String valueSet);
+
     // Single Code
     IgamtObjectError SingleCodeNotAllowed(String pathId, LocationInfo info, String id, Type type);
     IgamtObjectError SingleCodeMissingCode(String pathId, LocationInfo info, String id, Type type);
@@ -39,6 +44,7 @@ public interface VerificationEntryService {
     IgamtObjectError ValueSetBindingNotAllowed(String pathId, LocationInfo info, String id, Type type);
     IgamtObjectError MultipleValueSetNotAllowed(String pathId, LocationInfo info, String id, Type type);
     IgamtObjectError InvalidBindingLocation(String pathId, String locationName, LocationInfo target, PropertyType prop, String id, Type type, Set<Integer> bindingLocations, String reason);
+    IgamtObjectError OBX2MessageValueSetBindingNotAllowed(String pathId, LocationInfo info, String id, Type type);
 
     // Co-Constraints
     IgamtObjectError CoConstraintTargetIsNotSegment(String pathId, String locationName, String id, Type type, String path, String pathQualifier);
@@ -65,6 +71,8 @@ public interface VerificationEntryService {
     IgamtObjectError CoConstraintMultiDatatypeCells(String pathId, String locationName, String id, Type type);
     IgamtObjectError CoConstraintMultiVariesCells(String pathId, String locationName, String id, Type type);
     IgamtObjectError CoConstraintNoDatatypeCell(String pathId, String locationName, String id, Type type);
+    IgamtObjectError CoConstraintDatatypeCellNotAllowed(String pathId, String locationName, String id, Type type);
+
 
     // Conformance Statements and Predicates
     IgamtObjectError AssertionOccurrenceTypeOnNotRepeatable(Location location, String id, Type type, LocationInfo path, String occurrenceType, String pathQualifier);

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/CommonVerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/CommonVerificationService.java
@@ -6,15 +6,22 @@ import gov.nist.hit.hl7.igamt.datatype.domain.Datatype;
 import gov.nist.hit.hl7.igamt.datatype.domain.PrimitiveDatatype;
 import gov.nist.hit.hl7.igamt.datatype.service.DatatypeService;
 import gov.nist.hit.hl7.igamt.ig.domain.verification.IgamtObjectError;
+import gov.nist.hit.hl7.igamt.ig.domain.verification.Location;
 import gov.nist.hit.hl7.igamt.service.verification.VerificationEntryService;
+import gov.nist.hit.hl7.igamt.valueset.domain.Code;
+import gov.nist.hit.hl7.igamt.valueset.domain.CodeUsage;
+import gov.nist.hit.hl7.igamt.valueset.domain.Valueset;
+import gov.nist.hit.hl7.igamt.valueset.service.ValuesetService;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 public class CommonVerificationService {
@@ -23,6 +30,8 @@ public class CommonVerificationService {
 	VerificationEntryService verificationEntryService;
 	@Autowired
 	DatatypeService datatypeService;
+	@Autowired
+	ValuesetService valuesetService;
 
 	static final Predicate<String> extensionPattern = Pattern.compile("^[A-Za-z][\\w-]{0,7}$").asPredicate();
 
@@ -255,6 +264,100 @@ public class CommonVerificationService {
 			}
 		}
 		return errors;
+	}
+
+	List<IgamtObjectError> checkDynamicMappingInValueSet(Location location, String id, Type type, Set<Valueset> valueSets, Set<String> dynamicMappingValues) {
+		List<IgamtObjectError> issues = new ArrayList<>();
+		for(String value: dynamicMappingValues) {
+			issues.addAll(
+					this.checkDynamicMappingValueInValueSet(
+							location,
+							id,
+							type,
+							valueSets,
+							value
+					)
+			);
+		}
+
+		return issues;
+	}
+
+	List<IgamtObjectError>  checkDynamicMappingValueInValueSet(Location location, String id, Type type, Set<Valueset> valueSets, String value) {
+		List<IgamtObjectError> issues = new ArrayList<>();
+		Set<Valueset> validMatches = valueSets
+				.stream()
+				.filter((vs) -> vs.getCodes() != null)
+				.filter((vs) -> vs.getCodes()
+				                  .stream()
+				                  .anyMatch((code) -> code.getValue().equals(value) && (code.getUsage() == null || !code.getUsage().equals(CodeUsage.E)))
+				).collect(Collectors.toSet());
+
+		if(validMatches.size() > 0) {
+			return issues;
+		}
+
+		Set<Valueset> invalidMatches = valueSets
+				.stream()
+				.filter((vs) -> vs.getCodes() != null)
+				.filter((vs) -> vs.getCodes()
+				                  .stream()
+				                  .anyMatch((code) -> code.getValue().equals(value) && (code.getUsage() != null && code.getUsage().equals(CodeUsage.E)))
+				).collect(Collectors.toSet());
+
+		if(invalidMatches.size() > 0) {
+			// Found with excluded usage
+			issues.add(
+					this.verificationEntryService.DynamicMappingValueExcludedUsage(
+							location,
+							id,
+							type,
+							value,
+							invalidMatches.stream()
+							              .map(Valueset::getBindingIdentifier)
+							              .collect(Collectors.toSet())
+					)
+			);
+		} else {
+			// Not found
+			issues.add(
+					this.verificationEntryService.DynamicMappingValueNotFound(
+							location,
+							id,
+							type,
+							value,
+							valueSets.stream()
+							         .map(Valueset::getBindingIdentifier)
+							         .collect(Collectors.toSet())
+					)
+			);
+		}
+		return issues;
+	}
+
+	List<IgamtObjectError> checkValueSetValuesInDynamicMapping(Location location, String id, Type type, Set<Valueset> valueSets, Set<String> dynamicMappingValues) {
+		List<IgamtObjectError> issues = new ArrayList<>();
+		for(Valueset valueSet: valueSets) {
+			if(valueSet.getCodes() != null) {
+				Set<String> notMatched = valueSet.getCodes()
+				                                 .stream()
+				                                 .filter((code) -> code.getUsage() == null || ! code.getUsage().equals(CodeUsage.E))
+				                                 .map(Code::getValue)
+				                                 .filter((code) -> ! dynamicMappingValues.contains(code))
+				                                 .collect(Collectors.toSet());
+
+				if(notMatched.size() > 0) {
+					issues.add(this.verificationEntryService.DynamicMappingMissingValue(
+							location,
+							id,
+							type,
+							notMatched,
+							valueSet.getBindingIdentifier()
+					));
+				}
+			}
+		}
+		return issues;
 	}
 
 	public boolean isNullOrNA(String s) {

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
@@ -144,6 +144,36 @@ public class DefaultVerificationEntryService implements VerificationEntryService
     }
 
     @Override
+    public IgamtObjectError DynamicMappingValueNotFound(Location location, String id, Type type, String value, Set<String> valueSets) {
+        return new IgamtVerificationEntryBuilder("DYNAMIC_MAPPING_VALUE_NOT_FOUND")
+                .error()
+                .target(id, type)
+                .locationInfo(location)
+                .message("Dynamic mapping value '"+value+"' is not part of the value sets ["+ String.join(", ", valueSets)+"] bound at location "+ location.getName() +".")
+                .entry();
+    }
+
+    @Override
+    public IgamtObjectError DynamicMappingValueExcludedUsage(Location location, String id, Type type, String value, Set<String> valueSets) {
+        return new IgamtVerificationEntryBuilder("DYNAMIC_MAPPING_VALUE_EXCLUDED")
+                .error()
+                .target(id, type)
+                .locationInfo(location)
+                .message("Dynamic mapping value '"+value+"' has a usage code of 'E' (excluded) in value sets ["+ String.join(", ", valueSets)+"] bound at location "+ location.getName() +".")
+                .entry();
+    }
+
+    @Override
+    public IgamtObjectError DynamicMappingMissingValue(Location location, String id, Type type, Set<String> values, String valueSet) {
+        return new IgamtVerificationEntryBuilder("DYNAMIC_MAPPING_VALUE_MISSING")
+                .error()
+                .target(id, type)
+                .locationInfo(location)
+                .message("Values ["+ String.join(", ", values)+"] from value set '"+valueSet+"' do not have a datatype associated in the dynamic mapping.")
+                .entry();
+    }
+
+    @Override
     public IgamtObjectError SingleCodeNotAllowed(String pathId, LocationInfo info, String id, Type type) {
         return new IgamtVerificationEntryBuilder("SINGLE_CODE_NOT_ALLOWED")
                 .fatal()
@@ -202,6 +232,18 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .target(id, type)
                 .locationInfo(pathId, name, prop)
                 .message("Invalid binding location : " + (blIsSet ? bindingLocations : '.') + " at " + target.getHl7Path() + (!Strings.isNullOrEmpty(reason) ? " ("+ reason +")" : ""))
+                .entry();
+    }
+
+    @Override
+    public IgamtObjectError OBX2MessageValueSetBindingNotAllowed(
+            String pathId, LocationInfo info, String id, Type type
+    ) {
+        return new IgamtVerificationEntryBuilder("OBX2_MESSAGE_VS_NOT_ALLOWED")
+                .fatal()
+                .target(id, type)
+                .locationInfo(pathId, info, PropertyType.VALUESET)
+                .message("Message level value set binding not allowed on OBX-2, this location's value set determines dynamic datatype mappings for OBX-5 and should be managed at the OBX segment level")
                 .entry();
     }
 
@@ -463,7 +505,17 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .message("Co-Constraint Table has multiple a column of VARIES type but no DATATYPE column")
                 .entry();
     }
-    
+
+    @Override
+    public IgamtObjectError CoConstraintDatatypeCellNotAllowed(String pathId, String locationName, String id, Type type) {
+        return new IgamtVerificationEntryBuilder("COCONSTRAINT_DATATYPE_CELL_NOT_ALLOWED")
+                .fatal()
+                .target(id, type)
+                .locationInfo(pathId, locationName, PropertyType.COCONSTRAINTBINDING_CELL)
+                .message("Co-Constraint Table restriction due to OBX-5 dynamic mapping : the IF column group is restricted to only contain a CODE column for OBX-3 when the THEN group contains a DATATYPE column for OBX-2.")
+                .entry();
+    }
+
     @Override
     public IgamtObjectError AssertionOccurrenceTypeOnNotRepeatable(Location location, String id, Type type, LocationInfo path, String occurrenceType, String pathQualifier) {
         return new IgamtVerificationEntryBuilder("ASSERTION_OCCTYPE_NOT_REPEATABLE")

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/SegmentVerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/SegmentVerificationService.java
@@ -1,22 +1,27 @@
 package gov.nist.hit.hl7.igamt.service.verification.impl;
 import com.google.common.base.Strings;
 import gov.nist.hit.hl7.igamt.common.base.domain.LocationInfo;
-import gov.nist.hit.hl7.igamt.common.base.domain.Scope;
 import gov.nist.hit.hl7.igamt.common.base.domain.Type;
+import gov.nist.hit.hl7.igamt.common.binding.domain.StructureElementBinding;
+import gov.nist.hit.hl7.igamt.common.change.entity.domain.PropertyType;
 import gov.nist.hit.hl7.igamt.ig.domain.verification.IgamtObjectError;
+import gov.nist.hit.hl7.igamt.ig.domain.verification.Location;
 import gov.nist.hit.hl7.igamt.ig.model.ResourceRef;
 import gov.nist.hit.hl7.igamt.ig.service.ResourceBindingVerificationService;
+import gov.nist.hit.hl7.igamt.segment.domain.DynamicMappingItem;
 import gov.nist.hit.hl7.igamt.segment.domain.Field;
 import gov.nist.hit.hl7.igamt.segment.domain.Segment;
+import gov.nist.hit.hl7.igamt.valueset.domain.Valueset;
+import gov.nist.hit.hl7.igamt.valueset.service.ValuesetService;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 public class SegmentVerificationService extends VerificationUtils {
@@ -24,25 +29,97 @@ public class SegmentVerificationService extends VerificationUtils {
 	ResourceBindingVerificationService resourceBindingVerificationService;
 	@Autowired
 	CommonVerificationService commonVerificationService;
+	@Autowired
+	ValuesetService valuesetService;
 
 	List<IgamtObjectError> verifySegment(Segment segment) {
 		List<IgamtObjectError> errors = new ArrayList<>();
-		LocationInfo contextLocationInfo  = new LocationInfo(
-				segment.getName(),
-				segment.getName(),
-				null,
-				Type.SEGMENT,
-				null
+		LocationInfo contextLocationInfo = new LocationInfo(segment.getName(),
+		                                                    segment.getName(),
+		                                                    null,
+		                                                    Type.SEGMENT,
+		                                                    null
 		);
-		ResourceRef contextResourceRef = new ResourceRef(
-				Type.SEGMENT,
-				segment.getId()
-		);
-		// TODO: verify dynamic mapping
+		ResourceRef contextResourceRef = new ResourceRef(Type.SEGMENT, segment.getId());
+		errors.addAll(checkDynamicMapping(segment, contextLocationInfo, segment.getBinding().getChildren()));
 		errors.addAll(commonVerificationService.checkExtension(segment, segment.getExt()));
 		errors.addAll(checkFields(segment.getChildren(), contextLocationInfo, contextResourceRef));
 		errors.addAll(resourceBindingVerificationService.verifySegmentBindings(segment));
 		return errors;
+	}
+
+	List<IgamtObjectError> checkDynamicMapping(Segment segment, LocationInfo segmentLocationInfo, Set<StructureElementBinding> bindings) {
+		List<IgamtObjectError> issues = new ArrayList<>();
+		String targetElementId = segment.getDynamicMappingInfo().getReferenceFieldId();
+		if(segment.getDynamicMappingInfo() != null && !Strings.isNullOrEmpty(targetElementId) && bindings != null && bindings.size() > 0) {
+			Field dynamicMappingField = segment
+					.getChildren()
+					.stream()
+					.filter((field) -> targetElementId.equals(field.getId()))
+					.findFirst()
+					.orElse(null);
+
+			if(dynamicMappingField != null) {
+				StructureElementBinding structureElementBinding = bindings
+						.stream()
+						.filter((children) -> children.getElementId().equals(targetElementId))
+						.findFirst()
+						.orElse(null);
+
+				if(structureElementBinding != null && structureElementBinding.getValuesetBindings() != null && structureElementBinding.getValuesetBindings().size() > 0) {
+					Set<String> vsList = structureElementBinding.getValuesetBindings()
+					                                            .stream()
+					                                            .flatMap((vs) -> vs.getValueSets() != null ? vs.getValueSets().stream() : new ArrayList<String>().stream())
+					                                            .filter(Objects::nonNull)
+					                                            .filter((value) -> !Strings.isNullOrEmpty(value))
+					                                            .collect(Collectors.toSet());
+
+					Set<String> values = segment.getDynamicMappingInfo()
+					                            .getItems()
+					                            .stream()
+					                            .map(DynamicMappingItem::getValue)
+					                            .filter(Objects::nonNull)
+					                            .filter((value) -> !Strings.isNullOrEmpty(value))
+					                            .collect(Collectors.toSet());
+
+					if(vsList.size() > 0) {
+						LocationInfo field = getFieldLocationInfo(dynamicMappingField, segmentLocationInfo);
+						Set<Valueset> valueSets = vsList.stream()
+							.map((vsId) -> this.valuesetService.findById(vsId))
+							.filter(Objects::nonNull)
+							.collect(Collectors.toSet());
+						issues.addAll(
+								commonVerificationService.checkDynamicMappingInValueSet(
+										new Location(
+												targetElementId,
+												field,
+												PropertyType.DYNAMICMAPPING
+										),
+										segment.getId(),
+										segment.getType(),
+										valueSets,
+										values
+								)
+						);
+						issues.addAll(
+								commonVerificationService.checkValueSetValuesInDynamicMapping(
+										new Location(
+												targetElementId,
+												field,
+												PropertyType.DYNAMICMAPPING
+										),
+										segment.getId(),
+										segment.getType(),
+										valueSets,
+										values
+								)
+						);
+					}
+				}
+			}
+		}
+
+		return issues;
 	}
 
 	List<IgamtObjectError> checkFields(Set<Field> fields, LocationInfo parentLocationInfo, ResourceRef context) {

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/VocabularyBindingVerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/VocabularyBindingVerificationService.java
@@ -30,6 +30,22 @@ public class VocabularyBindingVerificationService extends VerificationUtils {
                 PropertyType.VALUESET,
                 pathId,
                 (target) -> {
+
+                    if(
+                            resourceSkeleton.getResourceRef().getType().equals(Type.CONFORMANCEPROFILE)
+                                    && isOBX_2(target.getParent().getFixedName(), target.getPosition())
+                    ) {
+                        errors.add(
+                                this.entry.OBX2MessageValueSetBindingNotAllowed(
+                                        pathId,
+                                        target.getLocationInfo(),
+                                        resourceSkeleton.getResource().getId(),
+                                        resourceSkeleton.getResource().getType()
+                                )
+                        );
+                        return errors;
+                    }
+
                     BindingInfo bindingInfo = getBindingInfo(target.getResource().getFixedName());
                     if(bindingInfo != null &&
                             isAllowedLocation(
@@ -196,6 +212,10 @@ public class VocabularyBindingVerificationService extends VerificationUtils {
 
     public boolean existsValueSet(String vsId) {
         return this.valuesetService.findById(vsId) != null;
+    }
+
+    public boolean isOBX_2(String resourceName, int position) {
+        return resourceName.equals("OBX") && position == 2;
     }
 
     @FunctionalInterface()

--- a/igamt-hl7-client-v2/src/app/modules/co-constraints/components/co-constraint-table/co-constraint-table.component.html
+++ b/igamt-hl7-client-v2/src/app/modules/co-constraints/components/co-constraint-table/co-constraint-table.component.html
@@ -37,7 +37,7 @@
           <div *ngIf="!delta" style="width: 100%; display: flex; justify-content: space-between;">
             <div>
               <button *ngIf="!vOnly && mode !== 'GROUP' && value.headers.grouper && (!value.groups || value.groups.length === 0)" (click)="clearGrouper()" class="btn btn-sm btn-danger"><i class="fa fa-times"></i></button>
-              <button *ngIf="!vOnly && (mode === 'GROUP' || (value.groups && value.groups.length > 0))" class="btn btn-sm btn-primary" (click)="setTableGrouper(false)"><i class="fa fa-pencil"></i></button>
+              <button *ngIf="!vOnly && !value.headers.grouper" class="btn btn-sm btn-primary" (click)="setTableGrouper(false)"><i class="fa fa-pencil"></i></button>
             </div>
             <ng-container *ngIf="getGrouperElementInfo(value.headers.grouper) | async as grouperInfo" >
               <div style="width: 100%; text-align: center;" *ngIf="grouperInfo.resolved" >

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/valueset/valueset.component.html
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/valueset/valueset.component.html
@@ -60,7 +60,7 @@
     </ng-container>
   </ng-container>
 
-  <div *ngIf="bindingInfo?.allowValueSets && !globalViewOnly" style="margin-left: 5px;">
+  <div *ngIf="bindingInfo?.allowValueSets && !isOXB2MessageLevel && !globalViewOnly" style="margin-left: 5px;">
     <button class="btn btn-sm btn-primary"  (click)="editBinding()"><i class="fa fa-pencil"></i></button>
   </div>
 </div>

--- a/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/valueset/valueset.component.ts
+++ b/igamt-hl7-client-v2/src/app/modules/shared/components/hl7-v2-tree/columns/valueset/valueset.component.ts
@@ -43,8 +43,6 @@ export interface IValueSetOrSingleCodeDisplay {
   styleUrls: ['./valueset.component.scss'],
 })
 export class ValuesetComponent extends HL7v2TreeColumnComponent<IValueSetOrSingleCodeBindings> implements OnInit, OnDestroy {
-
-  bindings: Array<IBinding<IValueSetOrSingleCode>>;
   freeze$: Observable<{
     context: IBindingContext,
     binding: IValueSetOrSingleCodeDisplay,
@@ -68,6 +66,7 @@ export class ValuesetComponent extends HL7v2TreeColumnComponent<IValueSetOrSingl
   alive: boolean;
   activeChangeLog$: Observable<IChangeReasonSection[]>;
   vsOrScBindings: IValueSetOrSingleCodeBindings;
+  isOXB2MessageLevel: boolean;
 
   constructor(
     dialog: MatDialog,
@@ -347,6 +346,8 @@ export class ValuesetComponent extends HL7v2TreeColumnComponent<IValueSetOrSingl
   }
 
   ngOnInit() {
+    const parentIsOBX = this.node && this.node.parent && this.node.parent.data && this.node.parent.data.type === Type.SEGMENTREF && this.node.parent.data.name === 'OBX';
+    this.isOXB2MessageLevel = parentIsOBX && this.position === 2 && this.context !== Type.SEGMENT;
     this.alive = true;
     this.value$.pipe(
       takeWhile(() => this.alive),


### PR DESCRIPTION
Detections Added

**Dynamic Mapping**
[ERROR]  Dynamic mapping value '{value}' is not part of the value sets [vs1, vs2] bound at location {location}
[ERROR]  Dynamic mapping value '{value}' has a usage code of 'E' (excluded) in value sets [vs1, vs2] bound at location {location}.
[ERROR]  Values [v2, v2] from value set {vs} do not have a datatype associated in the dynamic mapping for segment {segment}.

**ValueSet Binding**
[FATAL]  Message level value set binding not allowed for field OBX-2, this location's value set determines dynamic datatype mappings for OBX-5 and should be managed at the OBX segment level

**Co-Constraint Table**
[FATAL] Co-Constraint Table restriction due to OBX-5 dynamic mapping : the IF column group is restricted to only contain a CODE column for OBX-3 when the THEN group contains a DATATYPE column for OBX-2.