### PR TITLE
XML Export Fixes

### DIFF
--- a/datatype/src/main/java/gov/nist/hit/hl7/igamt/datatype/service/DatatypeService.java
+++ b/datatype/src/main/java/gov/nist/hit/hl7/igamt/datatype/service/DatatypeService.java
@@ -116,8 +116,9 @@ public interface DatatypeService {
 
 	Set<DisplayElement> convertDatatypeRegistry(DatatypeRegistry registry);
 
-//	public String findXMLRefIdById(String flavorId, String defaultHL7Version);
-	public String findXMLRefIdById(Datatype dt, String defaultHL7Version);
+	String getDatatypeIdentifier(Datatype resource, String defaultHL7Version);
+
+	String findXMLRefIdById(Datatype datatype, String defaultHL7Version);
 
 	void processAndSubstitute(Datatype resource, HashMap<RealKey, String> newKeys);
 }

--- a/datatype/src/main/java/gov/nist/hit/hl7/igamt/datatype/service/impl/DatatypeServiceImpl.java
+++ b/datatype/src/main/java/gov/nist/hit/hl7/igamt/datatype/service/impl/DatatypeServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import gov.nist.hit.hl7.igamt.common.base.domain.*;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,13 +35,6 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import gov.nist.hit.hl7.igamt.common.base.domain.Level;
-import gov.nist.hit.hl7.igamt.common.base.domain.Link;
-import gov.nist.hit.hl7.igamt.common.base.domain.RealKey;
-import gov.nist.hit.hl7.igamt.common.base.domain.Resource;
-import gov.nist.hit.hl7.igamt.common.base.domain.Scope;
-import gov.nist.hit.hl7.igamt.common.base.domain.Type;
-import gov.nist.hit.hl7.igamt.common.base.domain.ValuesetBinding;
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
 import gov.nist.hit.hl7.igamt.common.base.exception.ForbiddenOperationException;
 import gov.nist.hit.hl7.igamt.common.base.exception.ValidationException;
@@ -1187,19 +1181,22 @@ public class DatatypeServiceImpl implements DatatypeService {
 	}
 
 	@Override
-	public String findXMLRefIdById(Datatype dt, String defaultHL7Version) {
-		if (defaultHL7Version != null && dt.getDomainInfo() != null && dt.getDomainInfo().getVersion() != null) {
-			if (defaultHL7Version.equals(dt.getDomainInfo().getVersion())) {
-				return dt.getLabel();
-			} else {
-				return this.str(dt.getLabel() + "_" + dt.getDomainInfo().getVersion().replaceAll("\\.", "-"));
-			}
-		} else {
-			return dt.getLabel();
+	public String getDatatypeIdentifier(Datatype resource, String defaultHL7Version) {
+		String identifier = str(resource.getLabel());
+		String resourceVersion = resource.getDomainInfo().getVersion();
+		boolean defaultVersionIsSet = defaultHL7Version != null && !defaultHL7Version.isEmpty();
+		boolean versionIsSet = resourceVersion != null && !resourceVersion.isEmpty();
+		boolean isDefaultHL7Version = defaultVersionIsSet && versionIsSet && defaultHL7Version.equals(resourceVersion);
+		if(versionIsSet && !isDefaultHL7Version) {
+			identifier = identifier + "_" + resourceVersion.replaceAll("\\.", "-");
 		}
+		return identifier;
 	}
-	
-	
+
+	public String findXMLRefIdById(Datatype datatype, String defaultHL7Version) {
+		return this.getDatatypeIdentifier(datatype, defaultHL7Version);
+	}
+
 	@Override
 	public void processAndSubstitute(Datatype resource, HashMap<RealKey, String> newKeys) {
 

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/service/IgService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/service/IgService.java
@@ -100,7 +100,7 @@ public interface IgService {
 
   public IgDataModel generateDataModel(Ig ig) throws Exception;
 
-  public InputStream exportValidationXMLByZip(IgDataModel igModel, String[] conformanceProfileIds, String[] compositeProfileIds) throws CloneNotSupportedException, IOException, ClassNotFoundException, ProfileSerializationException, TableSerializationException, CoConstraintXMLSerializationException;
+  public InputStream exportValidationXMLByZip(IgDataModel igModel, String[] conformanceProfileIds, String[] compositeProfileIds) throws Exception;
   
   public Set<RelationShip> findUsage(Set<RelationShip> relations, Type type, String elementId);
   
@@ -117,6 +117,8 @@ public interface IgService {
   public CompositeProfileStructure createCompositeProfile(Ig ig,
                                                           CompositeProfileCreationWrapper wrapper);  
   public String findDefaultHL7VersionById(String id);
+
+  String findDefaultHL7Version(Ig ig);
 
   void removeChildren(String id);
 

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/service/XMLSerializeService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/ig/service/XMLSerializeService.java
@@ -41,6 +41,6 @@ public interface XMLSerializeService {
 
   void generateIS(ZipOutputStream out, String xmlStr, String fileName) throws IOException;
 
-  void normalizeIgModel(IgDataModel igModel, String[] conformanceProfileIds) throws CloneNotSupportedException, ClassNotFoundException, IOException;
+  void normalizeIgModel(IgDataModel igModel, String[] conformanceProfileIds) throws Exception;
 
 }

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/IgServiceImpl.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/impl/IgServiceImpl.java
@@ -1101,8 +1101,7 @@ public class IgServiceImpl implements IgService {
 
 	@Override
 	public InputStream exportValidationXMLByZip(IgDataModel igModel, String[] conformanceProfileIds,
-												String[] compositeProfileIds) throws CloneNotSupportedException, IOException, ClassNotFoundException,
-			ProfileSerializationException, TableSerializationException, CoConstraintXMLSerializationException {
+												String[] compositeProfileIds) throws Exception {
 
 		// Add composite profile generated resources to the IG's main list of resources
 		if(igModel.getAllFlavoredDatatypeDataModelsMap() != null) {
@@ -2010,20 +2009,23 @@ public class IgServiceImpl implements IgService {
 	@Override
 	public String findDefaultHL7VersionById(String id) {
 		Ig ig = this.findById(id);
+		return findDefaultHL7Version(ig);
+	}
 
+	public String findDefaultHL7Version(Ig ig) {
 		if (ig.getMetadata() != null && ig.getMetadata().getHl7Versions() != null
-				&& ig.getMetadata().getHl7Versions().size() > 0) {
+				&& !ig.getMetadata().getHl7Versions().isEmpty()) {
 			return ig.getMetadata().getHl7Versions().get(0);
 		}
 
 		if (ig.getConformanceProfileRegistry() != null && ig.getConformanceProfileRegistry().getChildren() != null
-				&& ig.getConformanceProfileRegistry().getChildren().size() > 0) {
+				&& !ig.getConformanceProfileRegistry().getChildren().isEmpty()) {
 			for (Link l : ig.getConformanceProfileRegistry().getChildren()) {
 				if (l.getDomainInfo() != null && l.getDomainInfo().getVersion() != null)
 					return l.getDomainInfo().getVersion();
 			}
 		}
-		return "NOTFOUND";
+		return null;
 	}
 
 	@Override

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/VerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/VerificationService.java
@@ -23,6 +23,7 @@ public interface VerificationService {
 	IgVerificationIssuesList verifyIg(Ig ig);
 	List<IgamtObjectError> verifyCoConstraintGroup(CoConstraintGroup coConstraintGroup);
 	IgVerificationIssuesList verify(
+			Ig ig,
 			List<CompositeProfileStructure> compositeProfiles,
 			List<ConformanceProfile> conformanceProfiles,
 			List<Segment> segments,

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/CommonVerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/CommonVerificationService.java
@@ -103,7 +103,7 @@ public class CommonVerificationService {
 				}
 			}
 
-			if(lengthType.equals(LengthType.UNSET)) {
+			if(lengthType.equals(LengthType.UNSET) && !element.getUsage().equals(Usage.X)) {
 				// Check length or conf length is set
 				results.add(this.verificationEntryService.LengthOrConfLengthMissing(location, id, type));
 			}

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationEntryService.java
@@ -71,8 +71,8 @@ public class DefaultVerificationEntryService implements VerificationEntryService
                 .fatal()
                 .handleByUser()
                 .target(resourceId, resourceType)
-                .locationInfo("resource.extension", "Resource Extension", PropertyType.EXT)
-                .message("Resource with label " + label + " from version "+ version +" has duplicate identifier.")
+                .locationInfo("resource.extension", "Resource Identifier", PropertyType.IDENTIFIER)
+                .message("Resource \"" + label + "\" has duplicate identifier (extension or identifier already in use).")
                 .entry();
     }
 

--- a/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationService.java
+++ b/ig/src/main/java/gov/nist/hit/hl7/igamt/service/verification/impl/DefaultVerificationService.java
@@ -1,20 +1,29 @@
 package gov.nist.hit.hl7.igamt.service.verification.impl;
 
 import gov.nist.hit.hl7.igamt.coconstraints.model.CoConstraintGroup;
+import gov.nist.hit.hl7.igamt.common.base.domain.Resource;
 import gov.nist.hit.hl7.igamt.compositeprofile.domain.CompositeProfileStructure;
 import gov.nist.hit.hl7.igamt.conformanceprofile.domain.ConformanceProfile;
 import gov.nist.hit.hl7.igamt.datatype.domain.Datatype;
+import gov.nist.hit.hl7.igamt.datatype.service.DatatypeService;
 import gov.nist.hit.hl7.igamt.ig.domain.Ig;
 import gov.nist.hit.hl7.igamt.ig.domain.verification.CompositeProfileVerificationResult;
 import gov.nist.hit.hl7.igamt.ig.domain.verification.IgVerificationIssuesList;
 import gov.nist.hit.hl7.igamt.ig.domain.verification.IgamtObjectError;
+import gov.nist.hit.hl7.igamt.ig.service.IgService;
 import gov.nist.hit.hl7.igamt.segment.domain.Segment;
+import gov.nist.hit.hl7.igamt.segment.service.SegmentService;
+import gov.nist.hit.hl7.igamt.service.verification.VerificationEntryService;
 import gov.nist.hit.hl7.igamt.valueset.domain.Valueset;
+import gov.nist.hit.hl7.igamt.valueset.service.ValuesetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,6 +43,16 @@ public class DefaultVerificationService implements gov.nist.hit.hl7.igamt.servic
 	CompositeProfileVerificationService compositeProfileVerificationService;
 	@Autowired
 	IgVerificationService igVerificationService;
+	@Autowired
+	VerificationEntryService entry;
+	@Autowired
+	ValuesetService valuesetService;
+	@Autowired
+	DatatypeService datatypeService;
+	@Autowired
+	SegmentService segmentService;
+	@Autowired
+	IgService igService;
 
 	@Override
 	public List<IgamtObjectError> verifySegment(Segment segment) {
@@ -70,8 +89,36 @@ public class DefaultVerificationService implements gov.nist.hit.hl7.igamt.servic
 		return this.coConstraintVerificationService.verifyCoConstraintGroup(coConstraintGroup);
 	}
 
+	public <T extends Resource> List<IgamtObjectError> verifyList(
+			List<T> resources,
+			Function<T, List<IgamtObjectError>> verify,
+			Function<T, String> getLabel,
+			boolean checkDuplicateLabel
+	) {
+		List<IgamtObjectError> issues = new ArrayList<>();
+		Set<String> labels = new HashSet<>();
+		for(T resource : resources) {
+			issues.addAll(verify.apply(resource));
+			if(checkDuplicateLabel) {
+				String label = getLabel.apply(resource);
+				if(labels.contains(label.toLowerCase())) {
+					issues.add(this.entry.DuplicateResourceIdentifier(
+							resource.getId(),
+							resource.getType(),
+							label,
+							resource.getDomainInfo().getVersion()
+					));
+				}  else {
+					labels.add(label.toLowerCase());
+				}
+			}
+		}
+		return issues;
+	}
+
 	@Override
 	public IgVerificationIssuesList verify(
+			Ig ig,
 			List<CompositeProfileStructure> compositeProfiles,
 			List<ConformanceProfile> conformanceProfiles,
 			List<Segment> segments,
@@ -79,30 +126,56 @@ public class DefaultVerificationService implements gov.nist.hit.hl7.igamt.servic
 			List<Valueset> valueSets,
 			List<CoConstraintGroup> coConstraintGroups
 	) {
+		String defaultHL7Version = this.igService.findDefaultHL7Version(ig);
 		IgVerificationIssuesList issuesList = new IgVerificationIssuesList();
 		if(conformanceProfiles != null) {
 			issuesList.setConformanceProfiles(
-					conformanceProfiles.stream().flatMap((cp) -> verifyConformanceProfile(cp).stream()).collect(Collectors.toList())
+					verifyList(
+							conformanceProfiles,
+							this::verifyConformanceProfile,
+							ConformanceProfile::getLabel,
+							false
+					)
 			);
 		}
 		if(segments != null) {
 			issuesList.setSegments(
-					segments.stream().flatMap((s) -> verifySegment(s).stream()).collect(Collectors.toList())
+					verifyList(
+							segments,
+							this::verifySegment,
+							(sg) -> segmentService.getSegmentIdentifier(sg, defaultHL7Version),
+							true
+					)
 			);
 		}
 		if(datatypes != null) {
 			issuesList.setDatatypes(
-					datatypes.stream().flatMap((d) -> verifyDatatype(d).stream()).collect(Collectors.toList())
+					verifyList(
+							datatypes,
+							this::verifyDatatype,
+							(dt) -> datatypeService.getDatatypeIdentifier(dt, defaultHL7Version),
+							true
+					)
 			);
 		}
 		if(valueSets != null) {
 			issuesList.setValueSets(
-					valueSets.stream().flatMap((v) -> verifyValueSet(v).stream()).collect(Collectors.toList())
+					verifyList(
+							valueSets,
+							this::verifyValueSet,
+							(vs) -> valuesetService.getBindingIdentifier(vs, defaultHL7Version),
+							true
+					)
 			);
 		}
 		if(coConstraintGroups != null) {
 			issuesList.setCoConstraintGroups(
-					coConstraintGroups.stream().flatMap((ccg) -> verifyCoConstraintGroup(ccg).stream()).collect(Collectors.toList())
+					verifyList(
+							coConstraintGroups,
+							this::verifyCoConstraintGroup,
+							CoConstraintGroup::getLabel,
+							false
+					)
 			);
 		}
 		if(compositeProfiles != null) {

--- a/igamt-hl7-client-v2/src/app/modules/ig/components/create-ig/create-ig.component.scss
+++ b/igamt-hl7-client-v2/src/app/modules/ig/components/create-ig/create-ig.component.scss
@@ -19,6 +19,8 @@
   grid-area: context;
   padding: 5px 5px 5px 20px;
   border-bottom: 2px solid lightgray;
+  display: flex;
+  align-items: center;
 }
 
 .metadata {

--- a/segment/src/main/java/gov/nist/hit/hl7/igamt/segment/service/SegmentService.java
+++ b/segment/src/main/java/gov/nist/hit/hl7/igamt/segment/service/SegmentService.java
@@ -107,7 +107,8 @@ public interface SegmentService extends ResourceService {
   Set<DisplayElement> convertSegments(Set<Segment> segments);
   DisplayElement convertSegment(Segment segment);
   Set<DisplayElement> convertSegmentRegistry(SegmentRegistry registry);
-  String findXMLRefIdById(Segment s, String defaultHL7Version);
+  String getSegmentIdentifier(Segment resource, String defaultHL7Version);
+  String findXMLRefIdById(Segment segment, String defaultHL7Version);
   String findObx2VsId(Segment s);  
   List<Segment> saveAll(Set<Segment> segments) throws ForbiddenOperationException;
 

--- a/segment/src/main/java/gov/nist/hit/hl7/igamt/segment/service/impl/SegmentServiceImpl.java
+++ b/segment/src/main/java/gov/nist/hit/hl7/igamt/segment/service/impl/SegmentServiceImpl.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import gov.nist.hit.hl7.igamt.common.base.domain.*;
 import gov.nist.hit.hl7.igamt.segment.domain.registry.SegmentRegistry;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,13 +38,6 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import gov.nist.hit.hl7.igamt.common.base.domain.Level;
-import gov.nist.hit.hl7.igamt.common.base.domain.Link;
-import gov.nist.hit.hl7.igamt.common.base.domain.Resource;
-import gov.nist.hit.hl7.igamt.common.base.domain.Scope;
-import gov.nist.hit.hl7.igamt.common.base.domain.Status;
-import gov.nist.hit.hl7.igamt.common.base.domain.Type;
-import gov.nist.hit.hl7.igamt.common.base.domain.ValuesetBinding;
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
 import gov.nist.hit.hl7.igamt.common.base.exception.ForbiddenOperationException;
 import gov.nist.hit.hl7.igamt.common.base.model.SectionType;
@@ -1224,19 +1218,22 @@ public class SegmentServiceImpl implements SegmentService {
 	private String str(String value) {
 		return value != null ? value : "";
 	}
-	
-	@Override
-	public String findXMLRefIdById(Segment s, String defaultHL7Version) {
-		if (defaultHL7Version != null && s.getDomainInfo() != null && s.getDomainInfo().getVersion() != null) {
-			if (defaultHL7Version.equals(s.getDomainInfo().getVersion())) {
-				return s.getLabel();
-			} else {
-				return this.str(s.getLabel() + "_" + s.getDomainInfo().getVersion().replaceAll("\\.", "-"));
-			}
-		} else {
-			return s.getLabel();
-		}
-	}
+
+  public String getSegmentIdentifier(Segment resource, String defaultHL7Version) {
+    String identifier = str(resource.getLabel());
+    String resourceVersion = resource.getDomainInfo().getVersion();
+    boolean defaultVersionIsSet = defaultHL7Version != null && !defaultHL7Version.isEmpty();
+    boolean versionIsSet = resourceVersion != null && !resourceVersion.isEmpty();
+    boolean isDefaultHL7Version = defaultVersionIsSet && versionIsSet && defaultHL7Version.equals(resourceVersion);
+    if(versionIsSet && !isDefaultHL7Version) {
+      identifier = identifier + "_" + resourceVersion.replaceAll("\\.", "-");
+    }
+    return identifier;
+  }
+
+  public String findXMLRefIdById(Segment segment, String defaultHL7Version) {
+    return getSegmentIdentifier(segment, defaultHL7Version);
+  }
 
   @Override
   public List<Segment> saveAll(Set<Segment> segments) throws ForbiddenOperationException {

--- a/valueset/src/main/java/gov/nist/hit/hl7/igamt/valueset/service/ValuesetService.java
+++ b/valueset/src/main/java/gov/nist/hit/hl7/igamt/valueset/service/ValuesetService.java
@@ -15,6 +15,7 @@ package gov.nist.hit.hl7.igamt.valueset.service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import gov.nist.hit.hl7.igamt.common.base.exception.ForbiddenOperationException;
 
@@ -77,8 +78,9 @@ public interface ValuesetService {
 	DisplayElement convertValueSet(Valueset valueset);
 	Set<DisplayElement> convertValueSets(Set<Valueset> valueSets);
 	Set<DisplayElement> convertValueSetRegistry(ValueSetRegistry registry);
-//	public String findXMLRefIdById(String vsId, String defaultHL7Version);
-	public String findXMLRefIdById(Valueset vs, String defaultHL7Version);
 	List<Valueset> saveAll(Set<Valueset> valueSets) throws ForbiddenOperationException;
+	String getBindingIdentifier(Valueset vs, String defaultHL7Version);
+	String findXMLRefIdById(Valueset valueset, String defaultHL7Version);
+
 	public List<Valueset> findDisplayFormatByIds(Set<String> ids);
 }

--- a/valueset/src/main/java/gov/nist/hit/hl7/igamt/valueset/service/impl/ValuesetServiceImpl.java
+++ b/valueset/src/main/java/gov/nist/hit/hl7/igamt/valueset/service/impl/ValuesetServiceImpl.java
@@ -12,12 +12,10 @@
 package gov.nist.hit.hl7.igamt.valueset.service.impl;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import gov.nist.hit.hl7.igamt.common.base.domain.ResourceOrigin;
 import gov.nist.hit.hl7.igamt.common.base.domain.Type;
 import gov.nist.hit.hl7.igamt.common.base.domain.display.DisplayElement;
 import gov.nist.hit.hl7.igamt.common.base.exception.ForbiddenOperationException;
@@ -356,26 +354,36 @@ public class ValuesetServiceImpl implements ValuesetService {
     	this.operationService.verifySave(valueSets);
     	return this.valuesetRepository.saveAll(valueSets);
     }
-	
-	@Override
-	public String findXMLRefIdById(Valueset vs, String defaultHL7Version) {
-		if (defaultHL7Version != null && vs.getDomainInfo() != null && vs.getDomainInfo().getVersion() != null
-				&& !vs.getBindingIdentifier().equals("HL70396")) {
-			if (defaultHL7Version.equals(vs.getDomainInfo().getVersion())) {
-				return this.str(vs.getBindingIdentifier());
-			} else {
-				return this
-						.str(vs.getBindingIdentifier() + "_" + vs.getDomainInfo().getVersion().replaceAll("\\.", "-"));
-			}
-		} else {
-			return this.str(vs.getBindingIdentifier());
-		}
-	}
 
-	private String str(String value) {
+    @Override
+    public String getBindingIdentifier(Valueset vs, String defaultHL7Version) {
+        boolean isHL7Origin = vs.getDomainInfo() != null &&
+                vs.getDomainInfo().getScope() != null &&
+                vs.getDomainInfo().getScope().equals(Scope.HL7STANDARD) &&
+                vs.getResourceOrigin() != null &&
+                vs.getResourceOrigin().equals(ResourceOrigin.HL7);
+        boolean hasHL7Type = vs.getHl7Type() != null && !vs.getHl7Type().isEmpty();
+        boolean isHL7 = isHL7Origin || hasHL7Type;
+        String identifier = str(vs.getBindingIdentifier());
+        String resourceVersion = isHL7 ? vs.getDomainInfo().getVersion() : null;
+        if(isHL7) {
+            boolean defaultVersionIsSet = defaultHL7Version != null && !defaultHL7Version.isEmpty();
+            boolean versionIsSet = resourceVersion != null && !resourceVersion.isEmpty();
+            boolean isDefaultHL7Version = defaultVersionIsSet && versionIsSet && defaultHL7Version.equals(resourceVersion);
+            if(versionIsSet && !isDefaultHL7Version) {
+                identifier = identifier + " v" + resourceVersion;
+            }
+        }
+        return identifier;
+    }
+
+    public String findXMLRefIdById(Valueset valueset, String defaultHL7Version) {
+        return this.getBindingIdentifier(valueset, defaultHL7Version);
+    }
+
+    private String str(String value) {
 		return value != null ? value : "";
 	}
-
 
     @Override
     public List<Valueset> findDisplayFormatByIds(Set<String> ids) {

--- a/web-app/src/main/java/gov/nist/hit/hl7/igamt/web/app/ig/IGDocumentController.java
+++ b/web-app/src/main/java/gov/nist/hit/hl7/igamt/web/app/ig/IGDocumentController.java
@@ -1506,6 +1506,7 @@ public class IGDocumentController extends BaseController {
 		if (ig != null)  {
 			IgProfileResourceSubSet subSet = this.igService.getIgProfileResourceSubSet(ig, selectedConformanceProfileIds, selectedCompositeProfileIds);
 			return this.verificationService.verify(
+					ig,
 					subSet.getCompositeProfiles(),
 					subSet.getConformanceProfiles(),
 					subSet.getSegments(),


### PR DESCRIPTION
- Fix Value Set's Binding Identifiers XML identifiers (only add the version to HL7 value sets when not from default version)
- Add improved duplicate identifiers checks in verification
- Fix export of duplicate value sets (used in co-constraints)
- Fix slicing flavors missing from the XML export
